### PR TITLE
feat: Add iterable variant of `StreamMap`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub use delay::Delay;
 pub use futures_map::FuturesMap;
 pub use futures_set::FuturesSet;
 pub use futures_tuple_set::FuturesTupleSet;
-pub use stream_map::StreamMap;
+pub use stream_map::{StreamMap, StreamMapIterable};
 pub use stream_set::StreamSet;
 
 use std::fmt;


### PR DESCRIPTION
For libp2p/rust-libp2p#6009 it would be great if we could iterate through the streams in a  `futures_bounded::StreamMap`.

Just implementing an iterator for that type unfortunately doesn't work because `StreamMap` boxes its inner streams and thus obscures the stream type.
This PR adds `StreamMapIterable` as a variant of `StreamMap` that doesn't do any boxing and implements `iter` and `iter_mut`.

Implementation wise, `StreamMapIterable` is just the old `StreamMap` but without boxing of streams, and `StreamMap` a wrapper around it.

## Notes / Open Questions

If we want be consistent with the rest of rust-libp2p, we should technically call the `StreamMapIterable` just `StreamMap`, and the old `StreamMap` with the boxing `StreamMapBoxed`. But that would a) break the API and b) also require to change all other types for consistency. I'd be fine with that as well, but went with the minimal change for now. Wdyt @thomaseizinger @jxs? 