### PR TITLE
feat: add typed iterators for `StreamMap` and `StreamSet`

### DIFF
--- a/src/stream_map.rs
+++ b/src/stream_map.rs
@@ -115,7 +115,7 @@ where
         }
     }
 
-    /// Returns an iterator over all streams whose inner type is `T`.
+    /// Returns an iterator over all streams of type `T` pushed via [`StreamMap::try_push`].
     ///
     /// If downcasting a stream to `T` fails it will be skipped in the iterator.
     pub fn iter_of_type<T>(&self) -> impl Iterator<Item = (&ID, &T)>
@@ -130,7 +130,8 @@ where
         })
     }
 
-    /// Returns an iterator with mutable access over all streams whose inner type is `T`.
+    /// Returns an iterator with mutable access over all streams of type `T`
+    /// pushed via [`StreamMap::try_push`].
     ///
     /// If downcasting a stream to `T` fails it will be skipped in the iterator.
     pub fn iter_mut_of_type<T>(&mut self) -> impl Iterator<Item = (&mut ID, &mut T)>

--- a/src/stream_map.rs
+++ b/src/stream_map.rs
@@ -115,17 +115,17 @@ where
         }
     }
 
-    pub fn iter<T>(&self) -> impl Iterator<Item = (&ID, &T)>
+    /// Returns an iterator over all streams whose inner type is `T`.
+    ///
+    /// If downcasting a stream to `T` fails it will be skipped in the iterator.
+    pub fn iter_typed<T>(&self) -> impl Iterator<Item = (&ID, &T)>
     where
         T: 'static,
     {
         self.inner.iter().filter_map(|a| {
             let pin = a.inner.inner.as_ref();
-            let pin = pin as Pin<&(dyn Any + Unpin + Send)>;
             let any = Pin::into_inner(pin) as &(dyn Any + Send);
-
             let inner = any.downcast_ref::<T>()?;
-
             Some((&a.key, inner))
         })
     }
@@ -327,7 +327,7 @@ mod tests {
         streams.try_push("1", FooStream).unwrap();
         streams.try_push("2", FooStream).unwrap();
 
-        assert_eq!(streams.iter::<FooStream>().count(), 2)
+        assert_eq!(streams.iter_typed::<FooStream>().count(), 2)
     }
 
     struct FooStream;

--- a/src/stream_map.rs
+++ b/src/stream_map.rs
@@ -118,7 +118,7 @@ where
     /// Returns an iterator over all streams whose inner type is `T`.
     ///
     /// If downcasting a stream to `T` fails it will be skipped in the iterator.
-    pub fn iter_typed<T>(&self) -> impl Iterator<Item = (&ID, &T)>
+    pub fn iter_of_type<T>(&self) -> impl Iterator<Item = (&ID, &T)>
     where
         T: 'static,
     {
@@ -133,7 +133,7 @@ where
     /// Returns an iterator with mutable access over all streams whose inner type is `T`.
     ///
     /// If downcasting a stream to `T` fails it will be skipped in the iterator.
-    pub fn iter_mut_typed<T>(&mut self) -> impl Iterator<Item = (&mut ID, &mut T)>
+    pub fn iter_mut_of_type<T>(&mut self) -> impl Iterator<Item = (&mut ID, &mut T)>
     where
         T: 'static,
     {
@@ -345,14 +345,14 @@ mod tests {
             streams.try_push(format!("ID{i}"), rx).unwrap();
             sender.push(tx);
         }
-        assert_eq!(streams.iter_typed::<mpsc::Receiver<()>>().count(), N);
-        for (i, (id, _)) in streams.iter_typed::<mpsc::Receiver<()>>().enumerate() {
+        assert_eq!(streams.iter_of_type::<mpsc::Receiver<()>>().count(), N);
+        for (i, (id, _)) in streams.iter_of_type::<mpsc::Receiver<()>>().enumerate() {
             let expect_id = format!("ID{}", N - i - 1); // Reverse order.
             assert_eq!(id, &expect_id);
         }
         assert!(!sender.iter().any(|tx| tx.is_closed()));
 
-        for (_, rx) in streams.iter_mut_typed::<mpsc::Receiver<()>>() {
+        for (_, rx) in streams.iter_mut_of_type::<mpsc::Receiver<()>>() {
             rx.close();
         }
         assert!(sender.iter().all(|tx| tx.is_closed()));

--- a/src/stream_map.rs
+++ b/src/stream_map.rs
@@ -129,6 +129,21 @@ where
             Some((&a.key, inner))
         })
     }
+
+    /// Returns an iterator with mutable access over all streams whose inner type is `T`.
+    ///
+    /// If downcasting a stream to `T` fails it will be skipped in the iterator.
+    pub fn iter_mut_typed<T>(&mut self) -> impl Iterator<Item = (&mut ID, &mut T)>
+    where
+        T: 'static,
+    {
+        self.inner.iter_mut().filter_map(|a| {
+            let pin = a.inner.inner.as_mut();
+            let any = Pin::into_inner(pin) as &mut (dyn Any + Send);
+            let inner = any.downcast_mut::<T>()?;
+            Some((&mut a.key, inner))
+        })
+    }
 }
 
 struct TimeoutStream<S> {

--- a/src/stream_set.rs
+++ b/src/stream_set.rs
@@ -62,20 +62,20 @@ where
     /// Returns an iterator over all streams whose inner type is `T`.
     ///
     /// If downcasting a stream to `T` fails it will be skipped in the iterator.
-    pub fn iter_typed<T>(&self) -> impl Iterator<Item = &T>
+    pub fn iter_of_type<T>(&self) -> impl Iterator<Item = &T>
     where
         T: 'static,
     {
-        self.inner.iter_typed().map(|(_, item)| item)
+        self.inner.iter_of_type().map(|(_, item)| item)
     }
 
     /// Returns an iterator with mutable access over all streams whose inner type is `T`.
     ///
     /// If downcasting a stream to `T` fails it will be skipped in the iterator.
-    pub fn iter_mut_typed<T>(&mut self) -> impl Iterator<Item = &mut T>
+    pub fn iter_mut_of_type<T>(&mut self) -> impl Iterator<Item = &mut T>
     where
         T: 'static,
     {
-        self.inner.iter_mut_typed().map(|(_, item)| item)
+        self.inner.iter_mut_of_type().map(|(_, item)| item)
     }
 }

--- a/src/stream_set.rs
+++ b/src/stream_set.rs
@@ -1,8 +1,6 @@
-use futures_util::stream::BoxStream;
-use futures_util::Stream;
 use std::task::{ready, Context, Poll};
 
-use crate::{Delay, PushError, StreamMap, Timeout};
+use crate::{AnyStream, BoxStream, Delay, PushError, StreamMap, Timeout};
 
 /// Represents a set of [Stream]s.
 ///
@@ -32,7 +30,7 @@ where
     /// In that case, the stream is not added to the set.
     pub fn try_push<F>(&mut self, stream: F) -> Result<(), BoxStream<O>>
     where
-        F: Stream<Item = O> + Send + 'static,
+        F: AnyStream<Item = O>,
     {
         self.id = self.id.wrapping_add(1);
 

--- a/src/stream_set.rs
+++ b/src/stream_set.rs
@@ -59,7 +59,8 @@ where
         Poll::Ready(res)
     }
 
-    /// Returns an iterator over all streams whose inner type is `T`.
+    /// Returns an iterator over all streams of type `T` pushed via [`StreamSet::try_push`].
+    ///
     ///
     /// If downcasting a stream to `T` fails it will be skipped in the iterator.
     pub fn iter_of_type<T>(&self) -> impl Iterator<Item = &T>
@@ -69,7 +70,8 @@ where
         self.inner.iter_of_type().map(|(_, item)| item)
     }
 
-    /// Returns an iterator with mutable access over all streams whose inner type is `T`.
+    /// Returns an iterator with mutable access over all streams of type `T`
+    /// pushed via [`StreamSet::try_push`].
     ///
     /// If downcasting a stream to `T` fails it will be skipped in the iterator.
     pub fn iter_mut_of_type<T>(&mut self) -> impl Iterator<Item = &mut T>

--- a/src/stream_set.rs
+++ b/src/stream_set.rs
@@ -58,4 +58,24 @@ where
 
         Poll::Ready(res)
     }
+
+    /// Returns an iterator over all streams whose inner type is `T`.
+    ///
+    /// If downcasting a stream to `T` fails it will be skipped in the iterator.
+    pub fn iter_typed<T>(&self) -> impl Iterator<Item = &T>
+    where
+        T: 'static,
+    {
+        self.inner.iter_typed().map(|(_, item)| item)
+    }
+
+    /// Returns an iterator with mutable access over all streams whose inner type is `T`.
+    ///
+    /// If downcasting a stream to `T` fails it will be skipped in the iterator.
+    pub fn iter_mut_typed<T>(&mut self) -> impl Iterator<Item = &mut T>
+    where
+        T: 'static,
+    {
+        self.inner.iter_mut_typed().map(|(_, item)| item)
+    }
 }

--- a/src/stream_set.rs
+++ b/src/stream_set.rs
@@ -61,7 +61,6 @@ where
 
     /// Returns an iterator over all streams of type `T` pushed via [`StreamSet::try_push`].
     ///
-    ///
     /// If downcasting a stream to `T` fails it will be skipped in the iterator.
     pub fn iter_of_type<T>(&self) -> impl Iterator<Item = &T>
     where


### PR DESCRIPTION
Based on discussion in #8 and draft #9.

## Notes

I renamed the functions to `iter{_mut}_typed` to avoid confusion with normal `iter`/ `iter_mut` and emphasize that streams that can't be downcasted will be skipped. Wdyt @thomaseizinger 

Also, a major version bump is needed because it breaks the API with the additional `Any` bound, right?