### PR TITLE
feat: add typed iterators for FuturesMap, FuturesSet, and FuturesTupleSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Next release
+
+- Allow iterating through future and stream collections.
+  Some types may need to be [pinned](https://docs.rs/rustc-std-workspace-std/latest/std/pin/macro.pin.html)
+  before being passed to `try_push`. This is a breaking change.
+  See [PR 11](https://github.com/thomaseizinger/rust-futures-bounded/pull/11).
+
 ## 0.3.0
 
 - Allow for multiple timer implementations.

--- a/src/futures_map.rs
+++ b/src/futures_map.rs
@@ -124,7 +124,7 @@ where
     }
 
     /// Returns an iterator over all futures of type `T` pushed via [`FuturesMap::try_push`].
-    /// The order that futures are returned is not guaranteed.
+    /// This iterator returns futures in an arbitrary order, which may change.
     ///
     /// If downcasting a future to `T` fails it will be skipped in the iterator.
     pub fn iter_of_type<T>(&self) -> impl Iterator<Item = (&ID, &T)>
@@ -141,7 +141,7 @@ where
 
     /// Returns an iterator with mutable access over all futures of type `T` pushed via
     /// [`FuturesMap::try_push`].
-    /// The order that futures are returned is not guaranteed.
+    /// This iterator returns futures in an arbitrary order, which may change.
     ///
     /// If downcasting a future to `T` fails it will be skipped in the iterator.
     pub fn iter_mut_of_type<T>(&mut self) -> impl Iterator<Item = (&mut ID, &mut T)>

--- a/src/futures_map.rs
+++ b/src/futures_map.rs
@@ -144,7 +144,7 @@ where
     /// This iterator returns futures in an arbitrary order, which may change.
     ///
     /// If downcasting a future to `T` fails it will be skipped in the iterator.
-    pub fn iter_mut_of_type<T>(&mut self) -> impl Iterator<Item = (&mut ID, &mut T)>
+    pub fn iter_mut_of_type<T>(&mut self) -> impl Iterator<Item = (&ID, &mut T)>
     where
         T: 'static,
     {
@@ -152,7 +152,7 @@ where
             let pin = a.inner.inner.as_mut();
             let any = Pin::into_inner(pin) as &mut (dyn Any + Send);
             let inner = any.downcast_mut::<T>()?;
-            Some((&mut a.tag, inner))
+            Some((&a.tag, inner))
         })
     }
 }

--- a/src/futures_set.rs
+++ b/src/futures_set.rs
@@ -60,7 +60,7 @@ where
     }
 
     /// Returns an iterator over all futures of type `T` pushed via [`FuturesSet::try_push`].
-    /// The order that futures are returned is not guaranteed.
+    /// This iterator returns futures in an arbitrary order, which may change.
     ///
     /// If downcasting a future to `T` fails it will be skipped in the iterator.
     pub fn iter_of_type<T>(&self) -> impl Iterator<Item = &T>
@@ -72,7 +72,7 @@ where
 
     /// Returns an iterator with mutable access over all futures of type `T`
     /// pushed via [`FuturesSet::try_push`].
-    /// The order that futures are returned is not guaranteed.
+    /// This iterator returns futures in an arbitrary order, which may change.
     ///
     /// If downcasting a future to `T` fails it will be skipped in the iterator.
     pub fn iter_mut_of_type<T>(&mut self) -> impl Iterator<Item = &mut T>

--- a/src/futures_set.rs
+++ b/src/futures_set.rs
@@ -1,9 +1,6 @@
-use std::future::Future;
 use std::task::{ready, Context, Poll};
 
-use futures_util::future::BoxFuture;
-
-use crate::{Delay, FuturesMap, PushError, Timeout};
+use crate::{AnyFuture, BoxFuture, Delay, FuturesMap, PushError, Timeout};
 
 /// Represents a list of [Future]s.
 ///
@@ -33,7 +30,7 @@ where
     /// In that case, the future is not added to the set.
     pub fn try_push<F>(&mut self, future: F) -> Result<(), BoxFuture<O>>
     where
-        F: Future<Output = O> + Send + 'static,
+        F: AnyFuture<Output = O>,
     {
         self.id = self.id.wrapping_add(1);
 
@@ -60,5 +57,28 @@ where
         let (_, res) = ready!(self.inner.poll_unpin(cx));
 
         Poll::Ready(res)
+    }
+
+    /// Returns an iterator over all futures of type `T` pushed via [`FuturesSet::try_push`].
+    /// The order that futures are returned is not guaranteed.
+    ///
+    /// If downcasting a future to `T` fails it will be skipped in the iterator.
+    pub fn iter_of_type<T>(&self) -> impl Iterator<Item = &T>
+    where
+        T: 'static,
+    {
+        self.inner.iter_of_type().map(|(_, item)| item)
+    }
+
+    /// Returns an iterator with mutable access over all futures of type `T`
+    /// pushed via [`FuturesSet::try_push`].
+    /// The order that futures are returned is not guaranteed.
+    ///
+    /// If downcasting a future to `T` fails it will be skipped in the iterator.
+    pub fn iter_mut_of_type<T>(&mut self) -> impl Iterator<Item = &mut T>
+    where
+        T: 'static,
+    {
+        self.inner.iter_mut_of_type().map(|(_, item)| item)
     }
 }

--- a/src/futures_tuple_set.rs
+++ b/src/futures_tuple_set.rs
@@ -67,7 +67,7 @@ where
     }
 
     /// Returns an iterator over all futures of type `T` pushed via [`FuturesTupleSet::try_push`].
-    /// The order that futures are returned is not guaranteed.
+    /// This iterator returns futures in an arbitrary order, which may change.
     ///
     /// If downcasting a future to `T` fails it will be skipped in the iterator.
     pub fn iter_of_type<T>(&self) -> impl Iterator<Item = (&T, &D)>
@@ -81,7 +81,7 @@ where
 
     /// Returns an iterator with mutable access over all futures of type `T`
     /// pushed via [`FuturesTupleSet::try_push`].
-    /// The order that futures are returned is not guaranteed.
+    /// This iterator returns futures in an arbitrary order, which may change.
     ///
     /// If downcasting a future to `T` fails it will be skipped in the iterator.
     pub fn iter_mut_of_type<T>(&mut self) -> impl Iterator<Item = (&mut T, &D)>

--- a/src/futures_tuple_set.rs
+++ b/src/futures_tuple_set.rs
@@ -76,7 +76,7 @@ where
     {
         self.inner
             .iter_of_type()
-            .map(|(id, item)| (item, self.data.get(&id).expect("must have data for future")))
+            .map(|(id, item)| (item, self.data.get(id).expect("must have data for future")))
     }
 
     /// Returns an iterator with mutable access over all futures of type `T`

--- a/src/futures_tuple_set.rs
+++ b/src/futures_tuple_set.rs
@@ -1,10 +1,7 @@
 use std::collections::HashMap;
-use std::future::Future;
 use std::task::{ready, Context, Poll};
 
-use futures_util::future::BoxFuture;
-
-use crate::{Delay, FuturesMap, PushError, Timeout};
+use crate::{AnyFuture, BoxFuture, Delay, FuturesMap, PushError, Timeout};
 
 /// Represents a list of tuples of a [Future] and an associated piece of data.
 ///
@@ -36,7 +33,7 @@ where
     /// In that case, the future is not added to the set.
     pub fn try_push<F>(&mut self, future: F, data: D) -> Result<(), (BoxFuture<O>, D)>
     where
-        F: Future<Output = O> + Send + 'static,
+        F: AnyFuture<Output = O>,
     {
         self.id = self.id.wrapping_add(1);
 
@@ -68,11 +65,41 @@ where
 
         Poll::Ready((res, data))
     }
+
+    /// Returns an iterator over all futures of type `T` pushed via [`FuturesTupleSet::try_push`].
+    /// The order that futures are returned is not guaranteed.
+    ///
+    /// If downcasting a future to `T` fails it will be skipped in the iterator.
+    pub fn iter_of_type<T>(&self) -> impl Iterator<Item = (&T, &D)>
+    where
+        T: 'static,
+    {
+        self.inner
+            .iter_of_type()
+            .map(|(id, item)| (item, self.data.get(&id).expect("must have data for future")))
+    }
+
+    /// Returns an iterator with mutable access over all futures of type `T`
+    /// pushed via [`FuturesTupleSet::try_push`].
+    /// The order that futures are returned is not guaranteed.
+    ///
+    /// If downcasting a future to `T` fails it will be skipped in the iterator.
+    pub fn iter_mut_of_type<T>(&mut self) -> impl Iterator<Item = (&mut T, &D)>
+    where
+        T: 'static,
+    {
+        // TODO: work out how to return &mut D here, without a
+        // "captured variable cannot escape `FnMut` closure body" compiler error
+        self.inner
+            .iter_mut_of_type()
+            .map(|(id, item)| (item, self.data.get(id).expect("must have data for future")))
+    }
 }
 
 #[cfg(all(test, feature = "futures-timer"))]
 mod tests {
     use super::*;
+    use futures::channel::oneshot;
     use futures_util::future::poll_fn;
     use futures_util::FutureExt;
     use std::future::ready;
@@ -90,5 +117,35 @@ mod tests {
 
         assert_eq!(res1.unwrap(), data1);
         assert_eq!(res2.unwrap(), data2);
+    }
+
+    #[test]
+    fn can_iter_typed_futures() {
+        const N: usize = 10;
+        let mut futures =
+            FuturesTupleSet::new(|| Delay::futures_timer(Duration::from_millis(100)), N);
+        let mut sender = Vec::with_capacity(N);
+        for i in 0..N {
+            let (tx, rx) = oneshot::channel::<()>();
+            futures
+                .try_push(rx, format!("Data{i}"))
+                .map_err(|_| PushError::BeyondCapacity(()))
+                .unwrap();
+            sender.push(tx);
+        }
+        assert_eq!(futures.iter_of_type::<oneshot::Receiver<()>>().count(), N);
+        for (i, (_, data)) in futures.iter_of_type::<oneshot::Receiver<()>>().enumerate() {
+            let expect_data = format!("Data{}", N - i - 1); // Reverse order.
+            assert_eq!(data, &expect_data);
+        }
+        assert!(!sender.iter().any(|tx| tx.is_canceled()));
+
+        for (rx, _) in futures.iter_mut_of_type::<oneshot::Receiver<()>>() {
+            rx.close();
+        }
+        assert!(sender.iter().all(|tx| tx.is_canceled()));
+
+        // Deliberately try a non-matching type
+        assert_eq!(futures.iter_mut_of_type::<()>().count(), 0);
     }
 }

--- a/src/futures_tuple_set.rs
+++ b/src/futures_tuple_set.rs
@@ -70,7 +70,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "futures-timer"))]
 mod tests {
     use super::*;
     use futures_util::future::poll_fn;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,3 +64,10 @@ pub trait AnyStream: futures_util::Stream + Any + Unpin + Send {}
 impl<T> AnyStream for T where T: futures_util::Stream + Any + Unpin + Send {}
 
 type BoxStream<T> = Pin<Box<dyn AnyStream<Item = T> + Send>>;
+
+#[doc(hidden)]
+pub trait AnyFuture: std::future::Future + Any + Unpin + Send {}
+
+impl<T> AnyFuture for T where T: std::future::Future + Any + Unpin + Send {}
+
+type BoxFuture<T> = Pin<Box<dyn AnyFuture<Output = T> + Send>>;

--- a/src/stream_map.rs
+++ b/src/stream_map.rs
@@ -116,7 +116,7 @@ where
     }
 
     /// Returns an iterator over all streams of type `T` pushed via [`StreamMap::try_push`].
-    /// The order that streams are returned is not guaranteed.
+    /// This iterator returns streams in an arbitrary order, which may change.
     ///
     /// If downcasting a stream to `T` fails it will be skipped in the iterator.
     pub fn iter_of_type<T>(&self) -> impl Iterator<Item = (&ID, &T)>
@@ -133,7 +133,7 @@ where
 
     /// Returns an iterator with mutable access over all streams of type `T`
     /// pushed via [`StreamMap::try_push`].
-    /// The order that streams are returned is not guaranteed.
+    /// This iterator returns streams in an arbitrary order, which may change.
     ///
     /// If downcasting a stream to `T` fails it will be skipped in the iterator.
     pub fn iter_mut_of_type<T>(&mut self) -> impl Iterator<Item = (&mut ID, &mut T)>

--- a/src/stream_map.rs
+++ b/src/stream_map.rs
@@ -116,6 +116,7 @@ where
     }
 
     /// Returns an iterator over all streams of type `T` pushed via [`StreamMap::try_push`].
+    /// The order that streams are returned is not guaranteed.
     ///
     /// If downcasting a stream to `T` fails it will be skipped in the iterator.
     pub fn iter_of_type<T>(&self) -> impl Iterator<Item = (&ID, &T)>
@@ -132,6 +133,7 @@ where
 
     /// Returns an iterator with mutable access over all streams of type `T`
     /// pushed via [`StreamMap::try_push`].
+    /// The order that streams are returned is not guaranteed.
     ///
     /// If downcasting a stream to `T` fails it will be skipped in the iterator.
     pub fn iter_mut_of_type<T>(&mut self) -> impl Iterator<Item = (&mut ID, &mut T)>
@@ -337,7 +339,7 @@ mod tests {
     }
 
     #[test]
-    fn can_iter_named_streams() {
+    fn can_iter_typed_streams() {
         const N: usize = 10;
         let mut streams = StreamMap::new(|| Delay::futures_timer(Duration::from_millis(100)), N);
         let mut sender = Vec::with_capacity(N);
@@ -357,6 +359,9 @@ mod tests {
             rx.close();
         }
         assert!(sender.iter().all(|tx| tx.is_closed()));
+
+        // Deliberately try a non-matching type
+        assert_eq!(streams.iter_mut_of_type::<()>().count(), 0);
     }
 
     struct Task {

--- a/src/stream_map.rs
+++ b/src/stream_map.rs
@@ -136,7 +136,7 @@ where
     /// This iterator returns streams in an arbitrary order, which may change.
     ///
     /// If downcasting a stream to `T` fails it will be skipped in the iterator.
-    pub fn iter_mut_of_type<T>(&mut self) -> impl Iterator<Item = (&mut ID, &mut T)>
+    pub fn iter_mut_of_type<T>(&mut self) -> impl Iterator<Item = (&ID, &mut T)>
     where
         T: 'static,
     {
@@ -144,7 +144,7 @@ where
             let pin = a.inner.inner.as_mut();
             let any = Pin::into_inner(pin) as &mut (dyn Any + Send);
             let inner = any.downcast_mut::<T>()?;
-            Some((&mut a.key, inner))
+            Some((&a.key, inner))
         })
     }
 }

--- a/src/stream_set.rs
+++ b/src/stream_set.rs
@@ -60,7 +60,7 @@ where
     }
 
     /// Returns an iterator over all streams of type `T` pushed via [`StreamSet::try_push`].
-    /// The order that streams are returned is not guaranteed.
+    /// This iterator returns streams in an arbitrary order, which may change.
     ///
     /// If downcasting a stream to `T` fails it will be skipped in the iterator.
     pub fn iter_of_type<T>(&self) -> impl Iterator<Item = &T>
@@ -72,7 +72,7 @@ where
 
     /// Returns an iterator with mutable access over all streams of type `T`
     /// pushed via [`StreamSet::try_push`].
-    /// The order that streams are returned is not guaranteed.
+    /// This iterator returns streams in an arbitrary order, which may change.
     ///
     /// If downcasting a stream to `T` fails it will be skipped in the iterator.
     pub fn iter_mut_of_type<T>(&mut self) -> impl Iterator<Item = &mut T>

--- a/src/stream_set.rs
+++ b/src/stream_set.rs
@@ -60,6 +60,7 @@ where
     }
 
     /// Returns an iterator over all streams of type `T` pushed via [`StreamSet::try_push`].
+    /// The order that streams are returned is not guaranteed.
     ///
     /// If downcasting a stream to `T` fails it will be skipped in the iterator.
     pub fn iter_of_type<T>(&self) -> impl Iterator<Item = &T>
@@ -71,6 +72,7 @@ where
 
     /// Returns an iterator with mutable access over all streams of type `T`
     /// pushed via [`StreamSet::try_push`].
+    /// The order that streams are returned is not guaranteed.
     ///
     /// If downcasting a stream to `T` fails it will be skipped in the iterator.
     pub fn iter_mut_of_type<T>(&mut self) -> impl Iterator<Item = &mut T>


### PR DESCRIPTION
This PR adds typed iterators for FuturesMap, FuturesSet, and FuturesTupleSet.

It also improves the existing documentation for these iterators on `StreamMap` and `StreamSet`, and improves test coverage.

#### Future Work

- Iterating through all IDs (of differently typed futures or streams)
- Iterating through all data (of differently typed `FuturesTupleSet` futures)